### PR TITLE
Fix 'Undefined variable: g:markdown_fenced_languages'

### DIFF
--- a/after/syntax/markdown.vim
+++ b/after/syntax/markdown.vim
@@ -18,7 +18,7 @@ syn region hugoShortcodeHighlight
       \ contains=markdownCode
 
 " [js=javascript, python, r] -> [javascript, python, r]
-for s:lang in map(copy(g:markdown_fenced_languages),'matchstr(v:val,"[^=]*$")')
+for s:lang in map(copy(['html', 'python', 'bash=sh']),'matchstr(v:val,"[^=]*$")')
   exe 'syn region hugoShortcodeHighlight'.s:lang
         \.' matchgroup=markdownCodeDelimiter'
         \.' start="{{<\s*highlight\s*\<'.s:lang.'\>\s*>}}"'


### PR DESCRIPTION
`g:markdown_fenced_languages` is a variable mentioned in the vim-markdown plugin and that also seems to be available by default in recent versions of vim (but not neovim, apparently): https://github.com/tpope/vim-markdown#vim-markdown-runtime-files=

I'm copy-pasting the said languages in this part to solve it.

[Closes #1]