### PR TITLE
Add ftdetect check for .hugo_build.lock

### DIFF
--- a/ftdetect/html.vim
+++ b/ftdetect/html.vim
@@ -1,5 +1,7 @@
 function! s:DetectGoTemplate()
-  if search('{{\s*end\s*}}')
+  if findfile('.hugo_build.lock', '.;') !=# ''
+    set ft=htmlhugo
+  elseif search('{{\s*end\s*}}')
     set ft=htmlhugo
   elseif search('{{\s*$\k\+\s*:=')
     set ft=htmlhugo


### PR DESCRIPTION
This commit adds an additional file type detection check to ensure html files will get the proper `htmlhugo` file type if saved before adding any template delimiters.  I find myself in this situation all the time.

This proposed check searches recursively upward from the directory of the current file for a `.hugo_build.lock` file and succeeds if found.

The original checks have been left to support pre-`0.89.0` versions of Hugo.
