### PR TITLE
Set `includeexpr` to append `.html`

### DIFF
--- a/ftplugin/htmlhugo.vim
+++ b/ftplugin/htmlhugo.vim
@@ -5,7 +5,7 @@ endif
 runtime! ftplugin/html.vim
 
 setlocal path+=layouts,resources,content,archetypes,static,data,layouts/_default,layouts/partials
-setlocal includeexpr=v:fname\.'.html'
+setlocal suffixesadd=.html
 
 setlocal commentstring={{/*%s*/}}
 

--- a/ftplugin/htmlhugo.vim
+++ b/ftplugin/htmlhugo.vim
@@ -5,6 +5,7 @@ endif
 runtime! ftplugin/html.vim
 
 setlocal path+=layouts,resources,content,archetypes,static,data,layouts/_default,layouts/partials
+setlocal includeexpr=v:fname\.'.html'
 
 setlocal commentstring={{/*%s*/}}
 


### PR DESCRIPTION
This allows `gf` to work on filenames given to partials with their `.html` extension dropped.