### PR TITLE
Gf shortcodes

### DIFF
--- a/ftdetect/html.vim
+++ b/ftdetect/html.vim
@@ -1,5 +1,13 @@
 function! s:DetectGoTemplate()
-  if findfile('.hugo_build.lock', '.;') !=# ''
+  if findfile('hugo.toml', '.;') !=# ''
+    set ft=htmlhugo
+  elseif findfile('hugo.yml', '.;') !=# ''
+    set ft=htmlhugo
+  elseif findfile('hugo.yaml', '.;') !=# ''
+    set ft=htmlhugo
+  elseif findfile('hugo.json', '.;') !=# ''
+    set ft=htmlhugo
+  elseif findfile('.hugo_build.lock', '.;') !=# ''
     set ft=htmlhugo
   elseif search('{{\s*end\s*}}')
     set ft=htmlhugo

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -1,0 +1,6 @@
+setlocal path+=layouts/shortcodes
+
+function s:trim_slash() abort
+  return substitute(v:fname, '^/', '', '').'.html'
+endfunction
+setlocal includeexpr=s:trim_slash()


### PR DESCRIPTION
Hello, me again!

So two commits here:

1. Make `gf` work for shortcodes.
2. Add ft detects for `hugo.{toml,yml,json}`

For the first, I extracted a `trim_slash` function because I couldn't for the life of me make `'/'` match as a regex within `includeexpr`.  If you know how, I'd love to know!

For the second, I totally understand if you don't want to merge it.  I just figure that now configs are called `hugo.xxx` that this is even better than checking for the lock file since the latter may not always exist (especially when you've just started a project).