### PR TITLE
Add b:match_words check

### DIFF
--- a/after/ftplugin/markdown.vim
+++ b/after/ftplugin/markdown.vim
@@ -1,4 +1,8 @@
 if exists('loaded_matchit')
+  if !exists('b:match_words')
+    let b:match_words=''
+  endif
+
   let b:match_words=''
         \.'\%({{<\s*\)\@<=\(\k\+\)\s\+.*>}}:'
         \.'\%({{<\s*\/\)\@<=\1\s*>}},'


### PR DESCRIPTION
BLUF: Addresses an edgecase where markdown filetype scripts may not have set `b:match_words` prior to this

---

In at least vim 9.1, legacy vimscript will not let you shift or put additional value(s) on a variable which doesn't yet exist. That is, to reassign a variable to include more values in addition to its current value, the variable must exist.

So `let b:match_words='' ... b:match_words` only works if b:match_words exists.

One would hope that `exists('loaded_matchit')` would be sufficient, but that assumes that the matchit plugin sets `b:match_words` itself, which it does not guarantee in at least vim 9.1. `b:match_words` is often set in filetype plugins, which may not actually occur.